### PR TITLE
Include dom macros

### DIFF
--- a/src/main/com/fulcrologic/fulcro_css/localized_dom.cljs
+++ b/src/main/com/fulcrologic/fulcro_css/localized_dom.cljs
@@ -1,5 +1,6 @@
 (ns com.fulcrologic.fulcro-css.localized-dom
   (:refer-clojure :exclude [map meta time use set symbol filter])
+  (:require-macros [com.fulcrologic.fulcro-css.localized-dom])
   (:require
     com.fulcrologic.fulcro.dom
     [com.fulcrologic.fulcro.components :as comp]


### PR DESCRIPTION
The dom macros was not included from clojurescript, which caused the fallback to be run all the time. The fallback function parses using spec/conform which adds a significat amount of time (10x and more) to the renders.

I don't know why it wasn't previously included and if there might be any reason to why it was left out.

Issue #3 