### PR TITLE
Update documentation regarding `:include-css`/`:include-children`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@
 
 image:https://img.shields.io/clojars/v/com.fulcrologic/fulcro-garden-css.svg[link=https://clojars.org/com.fulcrologic/fulcro-garden-css]
 
-This library adds co-located CSS support to Fulcro 3 components.  Fulcro 2.x and earlier have this 
+This library adds co-located CSS support to Fulcro 3 components.  Fulcro 2.x and earlier have this
 integrated by default, but 3+ enables this to be a pure library concern which allows more room for
 others to provide alternate approaches to solving the same problem.
 
@@ -44,6 +44,26 @@ others to provide alternate approaches to solving the same problem.
   {...normal options ...}
   (dom/div {}
     ;; Auto-scan the query to find components with CSS and inject it
+    (inj/style-element {:component Root})
+    ...))
+```
+
+To include CSS from components not present in the parent's query, use `:css-include`:
+
+```
+(defsc UtilityComponent [this props comp-props]
+ {:css [[:.red {:color "red"}]]}
+ (dom/div :.red))
+
+(def ui-utility-component ...)
+
+
+(defsc Root [this props]
+  {...normal options ...
+   ;; Include untracked component
+   :css-include [UtilityComponent]}
+  (dom/div {}
+    (ui-utility-component ...)
     (inj/style-element {:component Root})
     ...))
 ```

--- a/src/main/com/fulcrologic/fulcro_css/css.cljc
+++ b/src/main/com/fulcrologic/fulcro_css/css.cljc
@@ -17,7 +17,7 @@
 (def CSS? "`(CSS? class)` : Returns true if the given component has css." ci/CSS?)
 (def get-local-rules "`(get-local-rules class)` : Get the *raw* value from the local-rules of a component." ci/get-local-rules)
 (def get-global-rules "`(get-global-rules class)` : Get the *raw* value from the global-rules of a component." ci/get-global-rules)
-(def get-includes "`(get-inculdes class)` :Returns the list of components from the include-children method of a component" ci/get-includes)
+(def get-includes "`(get-inculdes class)` :Returns the list of components from the css-include method of a component" ci/get-includes)
 (def get-nested-includes "`(get-nested-includes class)` : Recursively finds all includes starting at the given component." ci/get-nested-includes)
 (def get-classnames "`(get-classnames class)` : Returns a map from user-given CSS rule names to localized names of the given component." ci/get-classnames)
 

--- a/src/main/com/fulcrologic/fulcro_css/css_implementation.cljc
+++ b/src/main/com/fulcrologic/fulcro_css/css_implementation.cljc
@@ -90,7 +90,7 @@
   (keyword (remove-prefix (name kw))))
 
 (defn get-includes
-  "Returns the list of components from the include-children method of a component"
+  "Returns the list of components from the css-include method of a component"
   [component]
   (let [includes (some-> component comp/component-options :css-include)]
     (if (fn? includes)


### PR DESCRIPTION
- Included documentation in readme about `:include-css` usage.
- Updated two docstrings that referred to `:include-children` such that they refer to `:include-css` instead.