### PR TITLE
Drop `cljsjs` react in favour of node modules

### DIFF
--- a/src/main/com/fulcrologic/fulcro_css/css.cljc
+++ b/src/main/com/fulcrologic/fulcro_css/css.cljc
@@ -3,7 +3,7 @@
             [com.fulcrologic.fulcro-css.css-implementation :as ci]
             [com.fulcrologic.fulcro.components :as comp]
             [clojure.string :as str]
-            #?(:cljs [cljsjs.react.dom])
+            #?(:cljs ["react-dom"])
             [clojure.walk :as walk]
             [garden.core :as g]
             [garden.selectors :as gs]))

--- a/src/main/com/fulcrologic/fulcro_css/localized_dom_common.cljc
+++ b/src/main/com/fulcrologic/fulcro_css/localized_dom_common.cljc
@@ -3,8 +3,8 @@
   (:require
     com.fulcrologic.fulcro-css.css
     #?(:clj [cljs.tagged-literals :refer [->JSValue]])
-    #?@(:cljs [[cljsjs.react]
-               [cljsjs.react.dom]
+    #?@(:cljs [["react"]
+               ["react-dom"]
                [goog.object :as gobj]])
     [com.fulcrologic.fulcro.components :as comp]
     [clojure.string :as str]))


### PR DESCRIPTION
Change the requires to pull in the `node_modules` installed react.

This change is needed for: https://github.com/awkay/workspaces/pull/6